### PR TITLE
Revert dependency updates

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 project.group=kr.summitsystems
-project.version=0.0.2-beta5
+project.version=0.0.2-beta4
 project.name=spring-bukkit
 project.url=https://github.com/summit-systems/spring-bukkit
 project.url.scm=https://github.com/summit-systems/spring-bukkit.git
@@ -26,8 +26,6 @@ spring.boot.version=3.1.5
 spring.data.jpa.version=3.1.5
 hibernate.version=6.2.13.Final
 hikaricp.version=5.0.1
-jakarta.persistence.api.version=3.1.0
-jakarta.transaction.api.version=2.0.1
 
 # Kotlin
 kotlin.version=1.8.22

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 project.group=kr.summitsystems
-project.version=0.0.2-beta6
+project.version=0.0.2-beta5
 project.name=spring-bukkit
 project.url=https://github.com/summit-systems/spring-bukkit
 project.url.scm=https://github.com/summit-systems/spring-bukkit.git

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,7 +38,6 @@ dependencyResolutionManagement {
 
             library("spring-boot-autoconfigure", "org.springframework.boot:spring-boot-autoconfigure:${extra["spring.boot.version"]}")
             library("spring-aspects", "org.springframework:spring-aspects:${extra["spring.version"]}")
-            library("spring-context", "org.springframework:spring-context:${extra["spring.version"]}")
 
             library("spring-data-jpa", "org.springframework.data:spring-data-jpa:${extra["spring.data.jpa.version"]}")
             library("hibernate-core", "org.hibernate.orm:hibernate-core:${extra["hibernate.version"]}")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,8 +42,6 @@ dependencyResolutionManagement {
             library("spring-data-jpa", "org.springframework.data:spring-data-jpa:${extra["spring.data.jpa.version"]}")
             library("hibernate-core", "org.hibernate.orm:hibernate-core:${extra["hibernate.version"]}")
             library("hikaricp", "com.zaxxer:HikariCP:${extra["hikaricp.version"]}")
-            library("jakarta-persistence-api", "jakarta.persistence:jakarta.persistence-api:${extra["jakarta.persistence.api.version"]}")
-            library("jakarta-transaction-api", "jakarta.transaction:jakarta.transaction-api:${extra["jakarta.transaction.api.version"]}")
 
             library("spring-test", "org.springframework.boot:spring-boot-starter-test:${extra["spring.boot.version"]}")
         }

--- a/spring-bukkit-core/build.gradle.kts
+++ b/spring-bukkit-core/build.gradle.kts
@@ -11,7 +11,6 @@ dependencies {
     api(libs.kotlinx.coroutines.core)
     api(libs.spring.boot.autoconfigure)
     api(libs.spring.aspects)
-    api(libs.spring.context)
 
     testImplementation(libs.spigot)
     testImplementation(libs.spring.test)

--- a/spring-bukkit-jpa/build.gradle.kts
+++ b/spring-bukkit-jpa/build.gradle.kts
@@ -9,8 +9,6 @@ dependencies {
     api(libs.spring.boot.autoconfigure)
     api(libs.spring.data.jpa)
     api(libs.hibernate.core)
-    api(libs.jakarta.persistence.api)
-    api(libs.jakarta.transaction.api)
     implementation(libs.hikaricp)
 
     testImplementation(libs.spigot)


### PR DESCRIPTION
To use Jakarta APIs or Spring-context without transitive dependencies, I added Jakarta/Spring-context dependencies.
but concluded that it was unnecessary. 
The reason is that there seems to be no need to use Jakarta APIs or Spring-context without Hibernate/Spring dependencies.